### PR TITLE
chore: upgrade golangci-lint to v1.64.8 and add config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,18 @@
+# golangci-lint v1.64.x — pinned in ./test via go install ...@v1.64.8
+run:
+  timeout: 5m
+
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - gofmt
+    - govet
+    - gosimple
+    - ineffassign
+    - misspell
+    - staticcheck
+    - unused
+
+issues:
+  max-same-issues: 50

--- a/cmd/keeper/cmd/keeper_test.go
+++ b/cmd/keeper/cmd/keeper_test.go
@@ -242,11 +242,11 @@ func TestGenerateHBA(t *testing.T) {
 			for _, o := range out {
 				b.WriteString(fmt.Sprintf("%s\n", o))
 			}
-			b.WriteString(fmt.Sprintf("\nwant:\n"))
+			b.WriteString("\nwant:\n")
 			for _, o := range tt.out {
 				b.WriteString(fmt.Sprintf("%s\n", o))
 			}
-			t.Errorf(b.String())
+			t.Error(b.String())
 		}
 	}
 }

--- a/cmd/stolonctl/cmd/register/serviceinfo.go
+++ b/cmd/stolonctl/cmd/register/serviceinfo.go
@@ -87,7 +87,7 @@ func (info *ServiceInfo) Compare(target ServiceInfo) bool {
 func NewServiceInfo(name string, db *cluster.DB, tags []string, isMaster bool) (*ServiceInfo, error) {
 	port, err := strconv.Atoi(db.Status.Port)
 	if err != nil {
-		return nil, fmt.Errorf(fmt.Sprintf("invalid database port '%s' for %s with uid %s", db.Status.Port, name, db.UID))
+		return nil, fmt.Errorf("invalid database port '%s' for %s with uid %s", db.Status.Port, name, db.UID)
 	}
 	return &ServiceInfo{
 		Name:     name,

--- a/cmd/stolonctl/cmd/register/serviceinfo_test.go
+++ b/cmd/stolonctl/cmd/register/serviceinfo_test.go
@@ -78,7 +78,7 @@ func TestConsulAgentServiceRegistration(t *testing.T) {
 		actual := service.ConsulAgentServiceRegistration()
 
 		if actual == nil {
-			t.Errorf("expected consul agent service registration not to be nil")
+			t.Fatalf("expected consul agent service registration not to be nil")
 		}
 		if actual.ID != service.ID {
 			t.Errorf("expected id to be %s but was %s", service.ID, actual.ID)

--- a/internal/cluster/v0/config_test.go
+++ b/internal/cluster/v0/config_test.go
@@ -109,7 +109,7 @@ func TestParseConfig(t *testing.T) {
 				t.Errorf("#%d: got no error, wanted error: %v", i, tt.err)
 			}
 			if !reflect.DeepEqual(cfg, tt.cfg) {
-				t.Errorf(spew.Sprintf("#%d: wrong config: got: %#v, want: %#v", i, cfg, tt.cfg))
+				t.Error(spew.Sprintf("#%d: wrong config: got: %#v, want: %#v", i, cfg, tt.cfg))
 			}
 		}
 

--- a/internal/postgresql/utils_test.go
+++ b/internal/postgresql/utils_test.go
@@ -59,7 +59,7 @@ func TestParseTimelineHistory(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			}
 			if !reflect.DeepEqual(tlsh, tt.tlsh) {
-				t.Errorf(spew.Sprintf("#%d: wrong timeline history: got: %#+v, want: %#+v", i, tlsh, tt.tlsh))
+				t.Error(spew.Sprintf("#%d: wrong timeline history: got: %#+v, want: %#+v", i, tlsh, tt.tlsh))
 			}
 		}
 	}

--- a/test
+++ b/test
@@ -83,8 +83,8 @@ fi
 
 
 echo "Checking with golangci-lint"
-curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b ${BINDIR} v1.23.6
-${BINDIR}/golangci-lint run --deadline 5m
+GOBIN="${BINDIR}" go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
+${BINDIR}/golangci-lint run --timeout 5m
 
 echo "Running tests"
 go test -timeout 3m ${COVER} $@ ${PACKAGES} ${RACE}


### PR DESCRIPTION
Upgrades golangci-lint from the v1.23.x era (installed via the release script with --deadline) to a pinned v1.64.8 build installed with go install, switches to --timeout, adds a root .golangci.yml so enabled linters stay explicit and stable, and fixes a handful of staticcheck / gosimple findings so the new run is clean.

Fixes [#1](https://github.com/hadizamani021/StolonX/issues/1).