### PR TITLE
feat: region-aware proxy routing for dual-homed Postgres

### DIFF
--- a/cmd/keeper/cmd/keeper.go
+++ b/cmd/keeper/cmd/keeper.go
@@ -101,6 +101,8 @@ type config struct {
 	debug              bool
 	pgListenAddress    string
 	pgAdvertiseAddress string
+	pgAdvertiseInternalAddress string
+	pgAdvertiseInternalPort    string
 	pgPort             string
 	pgAdvertisePort    string
 	pgBinPath          string
@@ -116,6 +118,8 @@ type config struct {
 	canBeMaster             bool
 	canBeSynchronousReplica bool
 	disableDataDirLocking   bool
+
+	region string
 }
 
 var cfg config
@@ -128,6 +132,8 @@ func init() {
 	CmdKeeper.PersistentFlags().StringVar(&cfg.dataDir, "data-dir", "", "data directory")
 	CmdKeeper.PersistentFlags().StringVar(&cfg.pgListenAddress, "pg-listen-address", "", "postgresql instance listening address, local address used for the postgres instance. For all network interface, you can set the value to '*'.")
 	CmdKeeper.PersistentFlags().StringVar(&cfg.pgAdvertiseAddress, "pg-advertise-address", "", "postgresql instance address from outside. Use it to expose ip different than local ip with a NAT networking config")
+	CmdKeeper.PersistentFlags().StringVar(&cfg.pgAdvertiseInternalAddress, "pg-advertise-internal-address", "", "optional address on a private network for same-region stolon-proxy routing (dual-homed Postgres); requires matching proxy and sentinel versions")
+	CmdKeeper.PersistentFlags().StringVar(&cfg.pgAdvertiseInternalPort, "pg-advertise-internal-port", "", "optional port for pg-advertise-internal-address; defaults to the advertised external port (--pg-advertise-port or --pg-port)")
 	CmdKeeper.PersistentFlags().StringVar(&cfg.pgPort, "pg-port", "5432", "postgresql instance listening port")
 	CmdKeeper.PersistentFlags().StringVar(&cfg.pgAdvertisePort, "pg-advertise-port", "", "postgresql instance port from outside. Use it to expose port different than local port with a PAT networking config")
 	CmdKeeper.PersistentFlags().StringVar(&cfg.pgBinPath, "pg-bin-path", "", "absolute path to postgresql binaries. If empty they will be searched in the current PATH")
@@ -144,6 +150,8 @@ func init() {
 	CmdKeeper.PersistentFlags().BoolVar(&cfg.canBeMaster, "can-be-master", true, "prevent keeper from being elected as master")
 	CmdKeeper.PersistentFlags().BoolVar(&cfg.canBeSynchronousReplica, "can-be-synchronous-replica", true, "prevent keeper from being chosen as synchronous replica")
 	CmdKeeper.PersistentFlags().BoolVar(&cfg.disableDataDirLocking, "disable-data-dir-locking", false, "disable locking on data dir. Warning! It'll cause data corruptions if two keepers are concurrently running with the same data dir.")
+
+	CmdKeeper.PersistentFlags().StringVar(&cfg.region, "region", "", "opaque region identifier for this keeper; must match stolon-proxy --region when routing via internal advertise address")
 
 	if err := CmdKeeper.PersistentFlags().MarkDeprecated("id", "please use --uid"); err != nil {
 		log.Fatal(err)
@@ -473,6 +481,8 @@ type PostgresKeeper struct {
 	dataDir            string
 	pgListenAddress    string
 	pgAdvertiseAddress string
+	pgAdvertiseInternalAddress string
+	pgAdvertiseInternalPort    string
 	pgPort             string
 	pgAdvertisePort    string
 	pgBinPath          string
@@ -502,6 +512,8 @@ type PostgresKeeper struct {
 
 	canBeMaster             *bool
 	canBeSynchronousReplica *bool
+
+	region string
 }
 
 func NewPostgresKeeper(cfg *config, end chan error) (*PostgresKeeper, error) {
@@ -525,6 +537,8 @@ func NewPostgresKeeper(cfg *config, end chan error) (*PostgresKeeper, error) {
 
 		pgListenAddress:    cfg.pgListenAddress,
 		pgAdvertiseAddress: cfg.pgAdvertiseAddress,
+		pgAdvertiseInternalAddress: cfg.pgAdvertiseInternalAddress,
+		pgAdvertiseInternalPort:    cfg.pgAdvertiseInternalPort,
 		pgPort:             cfg.pgPort,
 		pgAdvertisePort:    cfg.pgAdvertisePort,
 		pgBinPath:          cfg.pgBinPath,
@@ -543,6 +557,8 @@ func NewPostgresKeeper(cfg *config, end chan error) (*PostgresKeeper, error) {
 
 		canBeMaster:             &cfg.canBeMaster,
 		canBeSynchronousReplica: &cfg.canBeSynchronousReplica,
+
+		region: cfg.region,
 
 		e:   e,
 		end: end,
@@ -606,6 +622,7 @@ func (p *PostgresKeeper) updateKeeperInfo() error {
 		UID:        keeperUID,
 		ClusterUID: clusterUID,
 		BootUUID:   p.bootUUID,
+		Region:     p.region,
 		PostgresBinaryVersion: cluster.PostgresBinaryVersion{
 			Maj: maj,
 			Min: min,
@@ -715,6 +732,8 @@ func (p *PostgresKeeper) GetPGState(pctx context.Context) (*cluster.PostgresStat
 
 	pgState.ListenAddress = p.pgAdvertiseAddress
 	pgState.Port = p.pgAdvertisePort
+	pgState.InternalListenAddress = p.pgAdvertiseInternalAddress
+	pgState.InternalPort = p.pgAdvertiseInternalPort
 
 	initialized, err := p.pgm.IsInitialized()
 	if err != nil {

--- a/cmd/keeper/cmd/keeper.go
+++ b/cmd/keeper/cmd/keeper.go
@@ -132,7 +132,7 @@ func init() {
 	CmdKeeper.PersistentFlags().StringVar(&cfg.dataDir, "data-dir", "", "data directory")
 	CmdKeeper.PersistentFlags().StringVar(&cfg.pgListenAddress, "pg-listen-address", "", "postgresql instance listening address, local address used for the postgres instance. For all network interface, you can set the value to '*'.")
 	CmdKeeper.PersistentFlags().StringVar(&cfg.pgAdvertiseAddress, "pg-advertise-address", "", "postgresql instance address from outside. Use it to expose ip different than local ip with a NAT networking config")
-	CmdKeeper.PersistentFlags().StringVar(&cfg.pgAdvertiseInternalAddress, "pg-advertise-internal-address", "", "optional address on a private network for same-region stolon-proxy routing (dual-homed Postgres); requires matching proxy and sentinel versions")
+	CmdKeeper.PersistentFlags().StringVar(&cfg.pgAdvertiseInternalAddress, "pg-advertise-internal-address", "", "optional address on a private network for same-region stolon-proxy routing (dual-homed Postgres).")
 	CmdKeeper.PersistentFlags().StringVar(&cfg.pgAdvertiseInternalPort, "pg-advertise-internal-port", "", "optional port for pg-advertise-internal-address; defaults to the advertised external port (--pg-advertise-port or --pg-port)")
 	CmdKeeper.PersistentFlags().StringVar(&cfg.pgPort, "pg-port", "5432", "postgresql instance listening port")
 	CmdKeeper.PersistentFlags().StringVar(&cfg.pgAdvertisePort, "pg-advertise-port", "", "postgresql instance port from outside. Use it to expose port different than local port with a PAT networking config")

--- a/cmd/proxy/cmd/proxy.go
+++ b/cmd/proxy/cmd/proxy.go
@@ -53,6 +53,8 @@ type config struct {
 	stopListening bool
 	debug         bool
 
+	region string
+
 	keepAliveIdle     int
 	keepAliveCount    int
 	keepAliveInterval int
@@ -67,6 +69,7 @@ func init() {
 	CmdProxy.PersistentFlags().StringVar(&cfg.port, "port", "5432", "proxy listening port")
 	CmdProxy.PersistentFlags().BoolVar(&cfg.stopListening, "stop-listening", true, "stop listening on store error")
 	CmdProxy.PersistentFlags().BoolVar(&cfg.debug, "debug", false, "enable debug logging")
+	CmdProxy.PersistentFlags().StringVar(&cfg.region, "region", "", "opaque region identifier for this proxy; when set (and matching the master keeper region), connect via internalListenAddress from cluster data")
 	CmdProxy.PersistentFlags().IntVar(&cfg.keepAliveIdle, "tcp-keepalive-idle", 0, "set tcp keepalive idle (seconds)")
 	CmdProxy.PersistentFlags().IntVar(&cfg.keepAliveCount, "tcp-keepalive-count", 0, "set tcp keepalive probe count number")
 	CmdProxy.PersistentFlags().IntVar(&cfg.keepAliveInterval, "tcp-keepalive-interval", 0, "set tcp keepalive interval (seconds)")
@@ -80,6 +83,8 @@ type ClusterChecker struct {
 	uid           string
 	listenAddress string
 	port          string
+
+	region string
 
 	stopListening bool
 
@@ -105,6 +110,7 @@ func NewClusterChecker(uid string, cfg config) (*ClusterChecker, error) {
 		uid:              uid,
 		listenAddress:    cfg.listenAddress,
 		port:             cfg.port,
+		region:           cfg.region,
 		stopListening:    cfg.stopListening,
 		e:                e,
 		endPollonProxyCh: make(chan error),
@@ -186,6 +192,25 @@ func (c *ClusterChecker) SetProxyInfo(e store.Store, generation int64, proxyTime
 	return nil
 }
 
+// proxyMasterEndpoint chooses external (advertised) vs internal Postgres host/port for this proxy.
+func proxyMasterEndpoint(proxyRegion string, db *cluster.DB, masterKeeper *cluster.Keeper) (host, port string, internal bool) {
+	if db == nil {
+		return "", "", false
+	}
+	extHost := db.Status.ListenAddress
+	extPort := db.Status.Port
+	intHost := db.Status.InternalListenAddress
+	intPort := db.Status.InternalPort
+	if intPort == "" {
+		intPort = extPort
+	}
+	if proxyRegion != "" && masterKeeper != nil && masterKeeper.Status.Region != "" &&
+		proxyRegion == masterKeeper.Status.Region && intHost != "" {
+		return intHost, intPort, true
+	}
+	return extHost, extPort, false
+}
+
 // Check reads the cluster data and applies the right pollon configuration.
 func (c *ClusterChecker) Check() error {
 	cd, _, err := c.e.GetClusterData(context.TODO())
@@ -259,13 +284,28 @@ func (c *ClusterChecker) Check() error {
 		return nil
 	}
 
-	addr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(db.Status.ListenAddress, db.Status.Port))
+	masterKeeper := cd.Keepers[db.Spec.KeeperUID]
+	host, port, internalRoute := proxyMasterEndpoint(c.region, db, masterKeeper)
+	addr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(host, port))
 	if err != nil {
 		log.Errorw("cannot resolve db address", zap.Error(err))
 		c.sendPollonConfData(pollon.ConfData{DestAddr: nil})
 		return nil
 	}
-	log.Infow("master address", "address", addr)
+	masterKeeperRegion := ""
+	if masterKeeper != nil {
+		masterKeeperRegion = masterKeeper.Status.Region
+	}
+	route := "external"
+	if internalRoute {
+		route = "internal"
+	}
+	log.Infow("master postgres endpoint",
+		"route", route,
+		"proxy_region", c.region,
+		"master_keeper_region", masterKeeperRegion,
+		"address", addr.String(),
+	)
 	if err = c.SetProxyInfo(c.e, proxy.Generation, proxyTimeout); err != nil {
 		// if we failed to update our proxy info when a master is defined we
 		// cannot ignore this error since the sentinel won't know that we exist
@@ -283,10 +323,10 @@ func (c *ClusterChecker) Check() error {
 	// start proxing only if we are inside enabledProxies, this ensures that the
 	// sentinel has read our proxyinfo and knows we are alive
 	if util.StringInSlice(proxy.Spec.EnabledProxies, c.uid) {
-		log.Infow("proxying to master address", "address", addr)
+		log.Infow("proxying to master", "route", route, "address", addr.String())
 		c.sendPollonConfData(pollon.ConfData{DestAddr: addr})
 	} else {
-		log.Infow("not proxying to master address since we aren't in the enabled proxies list", "address", addr)
+		log.Infow("not proxying to master address since we aren't in the enabled proxies list", "route", route, "address", addr.String())
 		c.sendPollonConfData(pollon.ConfData{DestAddr: nil})
 	}
 

--- a/cmd/proxy/cmd/proxy_test.go
+++ b/cmd/proxy/cmd/proxy_test.go
@@ -1,0 +1,137 @@
+// Copyright 2015 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/sorintlab/stolon/internal/cluster"
+)
+
+func TestProxyMasterEndpoint(t *testing.T) {
+	db := &cluster.DB{
+		UID: "db1",
+		Spec: &cluster.DBSpec{
+			KeeperUID: "k1",
+		},
+		Status: cluster.DBStatus{
+			ListenAddress:         "10.0.0.1",
+			Port:                  "5432",
+			InternalListenAddress: "172.16.0.1",
+			InternalPort:          "6432",
+		},
+	}
+	keeperEU := &cluster.Keeper{
+		UID: "k1",
+		Status: cluster.KeeperStatus{
+			Region: "eu-west",
+		},
+	}
+
+	tests := []struct {
+		name          string
+		proxyRegion   string
+		db            *cluster.DB
+		masterKeeper  *cluster.Keeper
+		wantHost      string
+		wantPort      string
+		wantInternal  bool
+	}{
+		{
+			name:         "nil db",
+			db:           nil,
+			wantHost:     "",
+			wantPort:     "",
+			wantInternal: false,
+		},
+		{
+			name:         "external when proxy region unset",
+			proxyRegion:  "",
+			db:           db,
+			masterKeeper: keeperEU,
+			wantHost:     "10.0.0.1",
+			wantPort:     "5432",
+			wantInternal: false,
+		},
+		{
+			name:         "external when keeper region empty",
+			proxyRegion:  "eu-west",
+			db:           db,
+			masterKeeper: &cluster.Keeper{UID: "k1", Status: cluster.KeeperStatus{}},
+			wantHost:     "10.0.0.1",
+			wantPort:     "5432",
+			wantInternal: false,
+		},
+		{
+			name:         "external when regions mismatch",
+			proxyRegion:  "us-east",
+			db:           db,
+			masterKeeper: keeperEU,
+			wantHost:     "10.0.0.1",
+			wantPort:     "5432",
+			wantInternal: false,
+		},
+		{
+			name:         "external when internal address unset",
+			proxyRegion:  "eu-west",
+			db: &cluster.DB{
+				Spec:   db.Spec,
+				Status: cluster.DBStatus{ListenAddress: "10.0.0.1", Port: "5432"},
+			},
+			masterKeeper: keeperEU,
+			wantHost:     "10.0.0.1",
+			wantPort:     "5432",
+			wantInternal: false,
+		},
+		{
+			name:        "internal when regions match and internal set",
+			proxyRegion: "eu-west",
+			db:          db,
+			masterKeeper: &cluster.Keeper{
+				UID:    "k1",
+				Status: cluster.KeeperStatus{Region: "eu-west"},
+			},
+			wantHost:     "172.16.0.1",
+			wantPort:     "6432",
+			wantInternal: true,
+		},
+		{
+			name:        "internal port falls back to external port",
+			proxyRegion: "eu-west",
+			db: &cluster.DB{
+				Spec: db.Spec,
+				Status: cluster.DBStatus{
+					ListenAddress:         "10.0.0.1",
+					Port:                  "5432",
+					InternalListenAddress: "172.16.0.1",
+				},
+			},
+			masterKeeper: keeperEU,
+			wantHost:     "172.16.0.1",
+			wantPort:     "5432",
+			wantInternal: true,
+		},
+		{
+			name:         "nil master keeper uses external",
+			proxyRegion:  "eu-west",
+			db:           db,
+			masterKeeper: nil,
+			wantHost:     "10.0.0.1",
+			wantPort:     "5432",
+			wantInternal: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			host, port, internal := proxyMasterEndpoint(tt.proxyRegion, tt.db, tt.masterKeeper)
+			if host != tt.wantHost || port != tt.wantPort || internal != tt.wantInternal {
+				t.Fatalf("proxyMasterEndpoint() = (%q, %q, %v), want (%q, %q, %v)",
+					host, port, internal, tt.wantHost, tt.wantPort, tt.wantInternal)
+			}
+		})
+	}
+}

--- a/cmd/sentinel/cmd/sentinel.go
+++ b/cmd/sentinel/cmd/sentinel.go
@@ -244,6 +244,7 @@ func (s *Sentinel) updateKeepersStatus(cd *cluster.ClusterData, keepersInfo clus
 			s.CleanKeeperError(keeperUID)
 			// Update keeper status infos
 			k.Status.BootUUID = ki.BootUUID
+			k.Status.Region = ki.Region
 			k.Status.PostgresBinaryVersion.Maj = ki.PostgresBinaryVersion.Maj
 			k.Status.PostgresBinaryVersion.Min = ki.PostgresBinaryVersion.Min
 		}
@@ -298,6 +299,8 @@ func (s *Sentinel) updateKeepersStatus(cd *cluster.ClusterData, keepersInfo clus
 
 		db.Status.ListenAddress = dbs.ListenAddress
 		db.Status.Port = dbs.Port
+		db.Status.InternalListenAddress = dbs.InternalListenAddress
+		db.Status.InternalPort = dbs.InternalPort
 		db.Status.CurrentGeneration = dbs.Generation
 		if dbs.Healthy {
 			s.CleanDBError(db.UID)

--- a/doc/README.md
+++ b/doc/README.md
@@ -17,6 +17,7 @@ We suggest that you first read the [Stolon Architecture and Requirements](archit
 
 ### Misc topics
 
+* [Region-aware proxy routing (multi-region)](region_proxy_routing.md)
 * [Enabling pg_rewind](pg_rewind.md)
 * [Enabling synchronous replication](syncrepl.md)
 * [PostgreSQL SSL/TLS setup](ssl.md)

--- a/doc/commands/stolon-keeper.md
+++ b/doc/commands/stolon-keeper.md
@@ -38,7 +38,7 @@ stolon-keeper [flags]
       --pg-su-password string           postgres superuser password. Only one of --pg-su-password or --pg-su-passwordfile must be provided. Must be the same for all keepers.
       --pg-su-passwordfile string       postgres superuser password file. Only one of --pg-su-password or --pg-su-passwordfile must be provided. Must be the same for all keepers)
       --pg-su-username string           postgres superuser user name. Used for keeper managed instance access and pg_rewind based synchronization. It'll be created on db initialization. Defaults to the name of the effective user running stolon-keeper. Must be the same for all keepers.
-      --region string                   opaque region identifier for this keeper; compared by proxies when routing via internal advertise (see ../region_proxy_routing.md). Env: STKEEPER_REGION
+      --region string                   opaque region identifier for this keeper; compared by proxies when routing via internal advertise (see ../region_proxy_routing.md).
       --store-backend string            store backend type (etcdv2/etcd, etcdv3, consul or kubernetes)
       --store-ca-file string            verify certificates of HTTPS-enabled store servers using this CA bundle
       --store-cert-file string          certificate file for client identification to the store

--- a/doc/commands/stolon-keeper.md
+++ b/doc/commands/stolon-keeper.md
@@ -24,6 +24,8 @@ stolon-keeper [flags]
       --log-level string                debug, info (default), warn or error (default "info")
       --metrics-listen-address string   metrics listen address i.e "0.0.0.0:8080" (disabled by default)
       --pg-advertise-address string     postgresql instance address from outside. Use it to expose ip different than local ip with a NAT networking config
+      --pg-advertise-internal-address string optional address on a private network for same-region stolon-proxy routing (dual-homed Postgres); see ../region_proxy_routing.md
+      --pg-advertise-internal-port string optional port for pg-advertise-internal-address; defaults to advertised external port when unset
       --pg-advertise-port string        postgresql instance port from outside. Use it to expose port different than local port with a PAT networking config
       --pg-bin-path string              absolute path to postgresql binaries. If empty they will be searched in the current PATH
       --pg-listen-address string        postgresql instance listening address, local address used for the postgres instance. For all network interface, you can set the value to '*'.
@@ -36,6 +38,7 @@ stolon-keeper [flags]
       --pg-su-password string           postgres superuser password. Only one of --pg-su-password or --pg-su-passwordfile must be provided. Must be the same for all keepers.
       --pg-su-passwordfile string       postgres superuser password file. Only one of --pg-su-password or --pg-su-passwordfile must be provided. Must be the same for all keepers)
       --pg-su-username string           postgres superuser user name. Used for keeper managed instance access and pg_rewind based synchronization. It'll be created on db initialization. Defaults to the name of the effective user running stolon-keeper. Must be the same for all keepers.
+      --region string                   opaque region identifier for this keeper; compared by proxies when routing via internal advertise (see ../region_proxy_routing.md). Env: STKEEPER_REGION
       --store-backend string            store backend type (etcdv2/etcd, etcdv3, consul or kubernetes)
       --store-ca-file string            verify certificates of HTTPS-enabled store servers using this CA bundle
       --store-cert-file string          certificate file for client identification to the store

--- a/doc/commands/stolon-proxy.md
+++ b/doc/commands/stolon-proxy.md
@@ -21,6 +21,7 @@ stolon-proxy [flags]
       --log-level string                debug, info (default), warn or error (default "info")
       --metrics-listen-address string   metrics listen address i.e "0.0.0.0:8080" (disabled by default)
       --port string                     proxy listening port (default "5432")
+      --region string                   opaque region identifier for this proxy; when set (and matching the master keeper region), connect via internal advertise data from cluster data (see ../region_proxy_routing.md). Env: STPROXY_REGION
       --stop-listening                  stop listening on store error (default true)
       --store-backend string            store backend type (etcdv2/etcd, etcdv3, consul or kubernetes)
       --store-ca-file string            verify certificates of HTTPS-enabled store servers using this CA bundle

--- a/doc/commands/stolon-proxy.md
+++ b/doc/commands/stolon-proxy.md
@@ -21,7 +21,7 @@ stolon-proxy [flags]
       --log-level string                debug, info (default), warn or error (default "info")
       --metrics-listen-address string   metrics listen address i.e "0.0.0.0:8080" (disabled by default)
       --port string                     proxy listening port (default "5432")
-      --region string                   opaque region identifier for this proxy; when set (and matching the master keeper region), connect via internal advertise data from cluster data (see ../region_proxy_routing.md). Env: STPROXY_REGION
+      --region string                   opaque region identifier for this proxy; when set (and matching the master keeper region), connect via internal advertise data from cluster data (see ../region_proxy_routing.md).
       --stop-listening                  stop listening on store error (default true)
       --store-backend string            store backend type (etcdv2/etcd, etcdv3, consul or kubernetes)
       --store-ca-file string            verify certificates of HTTPS-enabled store servers using this CA bundle

--- a/doc/region_proxy_routing.md
+++ b/doc/region_proxy_routing.md
@@ -1,0 +1,56 @@
+# Region-aware proxy routing
+
+Multi-region deployments can expose PostgreSQL on **two addresses**: a **public** address (NAT/load balancer) used across regions and an optional **internal** address on a private network used when the **stolon-proxy** runs in the **same region** as the primary **keeper**.
+
+Stolon compares an opaque **region** string on the proxy (`--region`) with the primary keeper’s region from cluster data (`Keeper.Status.Region`, sourced from keeper `--region`). When they match (both non-empty and equal) **and** an internal advertise address is published in `DB.Status`, the proxy connects via **internal** host/port; otherwise it uses the usual advertised address (`ListenAddress` / `Port`), unchanged from older releases.
+
+This mechanism does **not** use cluster spec labels or label selectors (see cluster specification docs).
+
+## Operational checklist (dual-homed PostgreSQL)
+
+1. Configure Postgres to listen on the interfaces that serve both paths (`listen_addresses`, `pg_hba.conf`). Validate connectivity on **both** addresses before relying on routing.
+2. On each keeper, set **`--pg-advertise-address`** / **`--pg-advertise-port`** to what other regions and clients should use (external path).
+3. Optionally set **`--pg-advertise-internal-address`** and, if needed, **`--pg-advertise-internal-port`** for the private path. If the internal port is omitted, the advertised external port is reused for internal routing decisions.
+4. Set **`--region`** on keepers and proxies to the **same string** within a region (e.g. `eu-west-1`).
+5. Deploy **sentinel** and **proxy** binaries that understand the new cluster-data fields before relying on internal routing (see upgrade order below).
+
+## Flags summary
+
+### stolon-keeper
+
+| Flag | Meaning |
+|------|---------|
+| `--region string` | Opaque region id stored in keeper info and mirrored into cluster data. |
+| `--pg-advertise-internal-address string` | Private network host/IP advertised for same-region proxies. |
+| `--pg-advertise-internal-port string` | Optional; defaults to the effective advertised external port when unset. |
+
+Environment (via existing `STKEEPER_*` convention): e.g. `STKEEPER_REGION`, `STKEEPER_PG_ADVERTISE_INTERNAL_ADDRESS`, `STKEEPER_PG_ADVERTISE_INTERNAL_PORT`.
+
+### stolon-proxy
+
+| Flag | Meaning |
+|------|---------|
+| `--region string` | Region for this proxy; compared to the master keeper’s region to choose internal vs external endpoint. |
+
+Environment: `STPROXY_REGION`.
+
+## Upgrade order
+
+Rolling upgrades are backward compatible when new fields are unset:
+
+1. Upgrade **sentinel** first so it persists `Region` and internal listen fields into cluster data when present.
+2. Upgrade **keepers** and configure `--region` / internal advertise as needed.
+3. Upgrade **proxies** and set `--region` where internal routing should apply.
+
+Older proxies ignore unknown JSON fields on read and simply use external addresses until upgraded.
+
+## Backward compatibility
+
+| Setting | Behavior |
+|---------|----------|
+| Proxy `--region` empty | Always use external `ListenAddress` / `Port` (legacy behavior). |
+| Keeper `--region` empty | Master keeper region empty → internal path never selected. |
+| Internal listen address empty | Internal path disabled; external used. |
+| Region mismatch or failover to another region | Proxy uses external path automatically. |
+
+No changes to **cluster spec** are required for region routing.

--- a/doc/region_proxy_routing.md
+++ b/doc/region_proxy_routing.md
@@ -4,8 +4,6 @@ Multi-region deployments can expose PostgreSQL on **two addresses**: a **public*
 
 Stolon compares an opaque **region** string on the proxy (`--region`) with the primary keeper’s region from cluster data (`Keeper.Status.Region`, sourced from keeper `--region`). When they match (both non-empty and equal) **and** an internal advertise address is published in `DB.Status`, the proxy connects via **internal** host/port; otherwise it uses the usual advertised address (`ListenAddress` / `Port`), unchanged from older releases.
 
-This mechanism does **not** use cluster spec labels or label selectors (see cluster specification docs).
-
 ## Operational checklist (dual-homed PostgreSQL)
 
 1. Configure Postgres to listen on the interfaces that serve both paths (`listen_addresses`, `pg_hba.conf`). Validate connectivity on **both** addresses before relying on routing.

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -578,6 +578,9 @@ type KeeperStatus struct {
 
 	CanBeMaster             *bool `json:"canBeMaster,omitempty"`
 	CanBeSynchronousReplica *bool `json:"canBeSynchronousReplica,omitempty"`
+
+	// Region is copied from KeeperInfo; opaque string compared by proxies to choose internal vs external Postgres endpoints.
+	Region string `json:"region,omitempty"`
 }
 
 type Keeper struct {
@@ -664,6 +667,9 @@ type DBStatus struct {
 
 	ListenAddress string `json:"listenAddress,omitempty"`
 	Port          string `json:"port,omitempty"`
+	// InternalListenAddress / InternalPort mirror PostgresState for same-region proxy routing (optional).
+	InternalListenAddress string `json:"internalListenAddress,omitempty"`
+	InternalPort          string `json:"internalPort,omitempty"`
 
 	SystemID         string                   `json:"systemdID,omitempty"`
 	TimelineID       uint64                   `json:"timelineID,omitempty"`

--- a/internal/cluster/member.go
+++ b/internal/cluster/member.go
@@ -52,6 +52,9 @@ type KeeperInfo struct {
 
 	PostgresState *PostgresState `json:"postgresState,omitempty"`
 
+	// Region is an opaque deployment identifier (e.g. cloud region); used with proxy routing.
+	Region string `json:"region,omitempty"`
+
 	CanBeMaster             *bool `json:"canBeMaster,omitempty"`
 	CanBeSynchronousReplica *bool `json:"canBeSynchronousReplica,omitempty"`
 }
@@ -93,6 +96,9 @@ type PostgresState struct {
 
 	ListenAddress string `json:"listenAddress,omitempty"`
 	Port          string `json:"port,omitempty"`
+	// InternalListenAddress and InternalPort advertise a private path for same-region proxies.
+	InternalListenAddress string `json:"internalListenAddress,omitempty"`
+	InternalPort          string `json:"internalPort,omitempty"`
 
 	Healthy bool `json:"healthy,omitempty"`
 


### PR DESCRIPTION
Proxies in the same region as the primary keeper can connect via an optional internal advertise address; otherwise behavior matches prior releases.

issue: https://github.com/hadizamani021/StolonX/issues/7